### PR TITLE
[Bugfix] Misusing variable leads to kernel panic on cloning io request.

### DIFF
--- a/infiniswap_bd/is_mq.c
+++ b/infiniswap_bd/is_mq.c
@@ -216,8 +216,6 @@ void stackbd_make_request2(struct request_queue *q, struct request *req)
 {
     struct bio *bio = NULL;
     struct bio *b = req->bio;
-    int i;
-    int len = req->nr_phys_segments;
 
     spin_lock_irq(&stackbd.lock);
     if (!stackbd.bdev_raw)
@@ -230,15 +228,14 @@ void stackbd_make_request2(struct request_queue *q, struct request *req)
         printk("stackbd: Device not active yet, aborting\n");
         goto abort;
     }
-    for (i=0; i<len -1; i++){
-    	bio = bio_clone(b, GFP_ATOMIC);
-    	bio_list_add(&stackbd.bio_list, bio);
-    	b = b->bi_next;
+
+	for (; b; b = b->bi_next)
+	{
+		bio = bio_clone(b, GFP_ATOMIC);
+		bio->bi_end_io = (bio_end_io_t*)IS_stackbd_end_io;
+		bio->bi_private = (void*) uint64_from_ptr(req);
+		bio_list_add(&stackbd.bio_list, bio);
 	}
-    bio = bio_clone(b, GFP_ATOMIC);
-	bio->bi_end_io = (bio_end_io_t*)IS_stackbd_end_io;
-	bio->bi_private = (void*) uint64_from_ptr(req);
-    bio_list_add(&stackbd.bio_list, bio);
 
     wake_up(&req_event);
     spin_unlock_irq(&stackbd.lock);


### PR DESCRIPTION
#14 #23 mentioned the bug of Null pointer and kernel got into a soft lock. The bug happens in function `is_mq.c::stackbd_make_request2` .

The real intention of this function may be, first to copy all `struct bio` that attached to the `struct request`, and then add these `bio` into the request queue of 'stackbd'.

Misusing variable `req->nr_phys_segments` which means "Number of physical scatter gather segments in a request" ([kernel document](https://www.kernel.org/doc/html/latest/block/request.html)) led to out-of-range access to the request list.

